### PR TITLE
Pass --reveal-prefix option to ServePostProcessor

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -298,6 +298,12 @@ class NbConvertApp(JupyterApp):
         self._postprocessor_class_changed({'new': self.postprocessor_class})
         if self.postprocessor_factory:
             self.postprocessor = self.postprocessor_factory(parent=self)
+            # Ensure that the --reveal-prefix option is passed on to the postprocessor if necessary
+            if hasattr(self.postprocessor, 'reveal_prefix'):
+                for _, config_dict in self.config.items():
+                    if 'reveal_url_prefix' in config_dict:
+                        self.postprocessor.reveal_prefix = config_dict['reveal_url_prefix']
+                        break
 
     def start(self):
         """Run start after initialization process has completed"""


### PR DESCRIPTION
ServePostProcessor has an attribute called `reveal_prefix` that does not get set when users provide `--reveal-prefix` over the command-line. This is easy to observe, for example, if you call `jupyter nbconvert --reveal-prefix` with a directory named something other than "reveal.js". This PR fixes the issue by passing the --reveal-prefix option along to the ServePostProcessor instance.